### PR TITLE
Added python-tk as requirement

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,4 +1,5 @@
 sudo apt-get install python-pip
+sudo apt-get install python-tk
 sudo pip install pandas==0.18.1
 sudo pip install nltk==3.2.2
 sudo pip install plotly==1.13.0


### PR DESCRIPTION
Hi,

when trying the script I had also to install python-tk. Added this in the requirements.

BTW: The README and requirements are based on system wide installation of the packages. Wouldn't it be better to have virtualenv and do the installation there? Then version of the packages are always set for this tool.

/donkeyDau